### PR TITLE
Update minechem.cfg

### DIFF
--- a/config/minechem.cfg
+++ b/config/minechem.cfg
@@ -125,7 +125,7 @@ power {
 
 worldgen {
     # Should Minechem generate ore
-    B:generateOre=true
+    B:generateOre=false
 
     # Size of uranium clusters
     I:uraniumOreClusterSize=3


### PR DESCRIPTION
disable minechem uranium oregen, can only turn into yellorite and destroys big reactor balance